### PR TITLE
Added `auto` option for `language` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ You can specify your preferred language using the `language` parameter:
 
 ```typst
 #swiss-qr-bill(
-  language: "fr",  // Options: "de", "fr", "it", "en"
+  language: "fr",  // Options: auto, "de", "fr", "it", "en"
   account: "CH4431999123000889012",
   // ... other parameters
 )
 ```
 
-The default language is German ("de") if not specified.
+The default language is the current text language (via `#set text(lang: "..."` and parameter `..., language: auto,...`) and defaults to German if the text language is invalid!
 
 ## Parameters
 

--- a/payqr-swiss.typ
+++ b/payqr-swiss.typ
@@ -155,10 +155,10 @@
   reference: none,
   additional-info: none,
   billing-info: none,
-  language: "de",  // de, fr, it, or en
+  language: auto,  // auto (use text.lang with fallback to en), de, fr, it, or en
   standalone: false,  // false: floating element (default), true: force new page
   font: "auto"  // "auto": use spec-compliant fonts, "page": inherit from page, or specify font name
-) = {
+) = context {
   // If amount = 0 then it's a bill with a blank field for the amount
   if (amount < 0.01 or amount > 999999999.99) and amount != 0 {
     panic("Amount must be between 0.01 and 999999999.99")
@@ -174,7 +174,7 @@
     panic("Currency must be either CHF or EUR")
   }
 
-  let lang = languages.at(language, default: languages.en)
+  let lang = languages.at(if language == auto {text.lang} else {language}, default: languages.en)
 
   let compliant-fonts = (
      "arial", "frutiger", "helvetica", "liberation sans"

--- a/payqr-swiss.typ
+++ b/payqr-swiss.typ
@@ -174,7 +174,7 @@
     panic("Currency must be either CHF or EUR")
   }
 
-  let lang = languages.at(if language == auto {text.lang} else {language}, default: languages.en)
+  let lang = languages.at(if language == auto {text.lang} else {language}, default: languages.de)
 
   let compliant-fonts = (
      "arial", "frutiger", "helvetica", "liberation sans"


### PR DESCRIPTION
Hello,
Just a little thing I think might be neat. I've changed how the language is selected by adding a new parameter option: `auto`. If set to `auto`, the `text.lang` value is used to detect the language. Default is as usual German.

This also means, that the function is now a `context` function!

What do you think about this approach?